### PR TITLE
Fixes a non-problematic array overflow

### DIFF
--- a/lzna.cpp
+++ b/lzna.cpp
@@ -139,7 +139,7 @@ static void LznaFarDistModel_Init(LznaFarDistModel *d) {
 }
 
 void LZNA_InitLookup(LznaState *lut) {
-  int i;
+  int i, j;
 
   for (i = 0; i < 4; i++)
     lut->match_history[i + 4] = 1;
@@ -155,8 +155,9 @@ void LZNA_InitLookup(LznaState *lut) {
   LznaNibbleModel_Init(&lut->long_length_recent.second);
   LznaNibbleModel_InitN(&lut->long_length_recent.third, 1);
 
-  for (i = 0; i < 48; i++)
-    lut->short_length[0][i] = 0x2000;
+  for (i = 0; i < 12; i++)
+    for (j = 0; j < 4; j++)
+      lut->short_length[i][j] = 0x2000;
 
   LznaNearDistModel_Init(lut->near_dist, 2);
   LznaLowBitsDistanceModel_Init(lut->low_bits_of_distance, 2);


### PR DESCRIPTION
The original code should be fine because the array is big enough (48) elements. 
But the indexing overflows from one dimension into the other, which results in a compiler warning about undefined behaviour.

Also get's rid of the warning.