### PR TITLE
Derive seed for MurmurHash64A automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if (OOZ_BUILD_BUN)
     add_library(bunutil STATIC
         "fnv.cpp" "fnv.h"
         "murmur.cpp" "murmur.h"
+        "path_rep.cpp" "path_rep.h"
         "util.cpp" "util.h"
         "utf.cpp" "utf.h"
         )
@@ -88,7 +89,7 @@ if (OOZ_BUILD_BUN)
 
     add_subdirectory(libpoe)
 
-    add_executable(bun_extract_file "bun_extract_file.cpp" "path_rep.cpp" "path_rep.h" "ggpk_vfs.cpp" "ggpk_vfs.h")
+    add_executable(bun_extract_file "bun_extract_file.cpp" "ggpk_vfs.cpp" "ggpk_vfs.h")
     target_link_libraries(bun_extract_file PRIVATE libbun libpoe)
     if (UNIX)
         target_link_libraries(bun_extract_file PRIVATE "-lstdc++fs")


### PR DESCRIPTION
Given the hash of the empty string for the root directory entry we can deterministically derive the seed used for MurmurHash64A.

Mathematically, this is possible due to how all three steps (xor, mul, xor) of hashing an empty string with this algorithm are invertible.

As we don't know what algorithm could be used in the future the code has a safeguard in that it validates the computed seed against the hash of the next non-empty directory path rep.