### PR TITLE
feat: consume less resources and faster extraction

### DIFF
--- a/bun_extract_file.cpp
+++ b/bun_extract_file.cpp
@@ -42,6 +42,7 @@ int main(int argc, char *argv[]) {
   std::filesystem::path ggpk_or_steam_dir;
   std::filesystem::path output_dir;
   bool use_regex = false;
+  bool use_mmap = false;
   std::vector<std::string> tail_args;
 
   command = argv[1];
@@ -50,6 +51,12 @@ int main(int argc, char *argv[]) {
   while (argi < argc) {
     if (argv[argi] == "--regex"sv) {
       use_regex = true;
+      ++argi;
+    } else if (argv[argi] == "--mmap"sv) {
+      use_mmap = true;
+      ++argi;
+    } else if (argv[argi] == "--no-mmap"sv) {
+      use_mmap = false;
       ++argi;
     } else {
       break;
@@ -79,7 +86,7 @@ int main(int argc, char *argv[]) {
 
   std::shared_ptr<GgpkVfs> vfs;
   if (ggpk_or_steam_dir.extension() == ".ggpk") {
-    vfs = open_ggpk(ggpk_or_steam_dir);
+    vfs = open_ggpk(ggpk_or_steam_dir, use_mmap);
   }
 
 #if _WIN32

--- a/ggpk_vfs.cpp
+++ b/ggpk_vfs.cpp
@@ -1,14 +1,18 @@
 #include "ggpk_vfs.h"
 
 #include <poe/util/utf.hpp>
+#include <filesystem>
+#include <fstream>
 
 struct GgpkVfs {
 	Vfs vfs;
+	std::filesystem::path path;
 	std::unique_ptr<poe::format::ggpk::parsed_ggpk> pack;
 };
 
-std::shared_ptr<GgpkVfs> open_ggpk(std::filesystem::path ggpk_path) {
+std::shared_ptr<GgpkVfs> open_ggpk(std::filesystem::path ggpk_path, bool mmap_data) {
 	auto ret = std::make_shared<GgpkVfs>();
+	ret->path = ggpk_path;
 	ret->pack = poe::format::ggpk::index_ggpk(ggpk_path);
 	if (!ret->pack) {
 		return {};
@@ -49,16 +53,34 @@ std::shared_ptr<GgpkVfs> open_ggpk(std::filesystem::path ggpk_path) {
 		auto* f = reinterpret_cast<ggpk::parsed_file const*>(file);
 		return f ? f->data_size_ : -1;
 	};
-	ret->vfs.read = [](Vfs* vfs, VfsFile* file, uint8_t* out, int64_t offset, int64_t size) -> int64_t {
-		auto* gvfs = reinterpret_cast<GgpkVfs*>(vfs);
-		auto* f = reinterpret_cast<ggpk::parsed_file const*>(file);
-		if (offset + size > (int64_t)f->data_size_) {
-			return -1;
-		}
-		memcpy(out, gvfs->pack->mapping_.data() + f->data_offset_ + offset, size);
-		return size;
-	};
-	ret->pack = poe::format::ggpk::index_ggpk(ggpk_path);
+
+	if (mmap_data) {
+		auto const read_via_mmap = [](Vfs* vfs, VfsFile* file, uint8_t* out, int64_t offset, int64_t size) -> int64_t {
+			auto* gvfs = reinterpret_cast<GgpkVfs*>(vfs);
+			auto* f = reinterpret_cast<ggpk::parsed_file const*>(file);
+			if (offset + size > (int64_t)f->data_size_) {
+				return -1;
+			}
+			memcpy(out, gvfs->pack->mapping_.data() + f->data_offset_ + offset, size);
+			return size;
+		};
+
+		ret->vfs.read = read_via_mmap;
+	} else {
+		auto const read_via_file = [](Vfs* vfs, VfsFile* file, uint8_t* out, int64_t offset, int64_t size) -> int64_t {
+			auto* gvfs = reinterpret_cast<GgpkVfs*>(vfs);
+			auto* f = reinterpret_cast<ggpk::parsed_file const*>(file);
+			if (offset + size > (int64_t)f->data_size_) {
+				return -1;
+			}
+			std::ifstream ifs(gvfs->path, std::ios::binary);
+			ifs.seekg(f->data_offset_ + offset);
+			ifs.read((char *)out, size);
+			return size;
+		};
+
+		ret->vfs.read = read_via_file;
+	}
 	return ret;
 }
 

--- a/ggpk_vfs.h
+++ b/ggpk_vfs.h
@@ -9,5 +9,5 @@ namespace ggpk = poe::format::ggpk;
 
 struct GgpkVfs;
 
-std::shared_ptr<GgpkVfs> open_ggpk(std::filesystem::path path);
+std::shared_ptr<GgpkVfs> open_ggpk(std::filesystem::path path, bool mmap_data = false);
 Vfs* borrow_vfs(std::shared_ptr<GgpkVfs>& vfs);


### PR DESCRIPTION
There were some low-hanging performance fruit that this PR addresses.

If using GGPK files, they were indexed twice by mistake.

Whole bundle decompression allocated memory for each block even if it could be decompressed directly into the target buffer. They now decompress in-place for all but the final block as that still needs safe space at the end.

Directories were redundantly created recursively for each file extracted, leading to a lot of filesystem churn and overhead. The directory tree is now gathered and created up-front.

Using memory-mapped I/O for the GGPK file had a tendency to build up a lot of RAM usage during processing, there is now and option to use regular file I/O for reading file data and only use memory mapping for the initial metadata sweep.
This can be chosen by `--mmap` and `--no-mmap` command line options, the default is `--no-mmap`.